### PR TITLE
Added *oaf -> *oaves

### DIFF
--- a/attache.plural.js
+++ b/attache.plural.js
@@ -81,6 +81,7 @@
 		[ /foot$/i, 'feet' ],
 		[ /zoon$/i, 'zoa' ],
 		[ /([tcsx])is$/i, '$1es' ],
+		[ /oaf$/i, 'oaves' ],
 
 		// fully assimilated suffixes
 		[ /ix$/i, 'ices' ],


### PR DESCRIPTION
"Loaf" was not being pluralized correctly. Added a rule for anything ending in "oaf" to pluralize to "oaves".
